### PR TITLE
Refactor zk-luhmann-index-level to call zk--parse-id with single ID

### DIFF
--- a/zk-luhmann.el
+++ b/zk-luhmann.el
@@ -503,7 +503,8 @@ Passes ARGS to `zk-index'."
                 (dotimes (_ reps)
                   (setq new-slug (concat new-slug slug))))
               (concat base-rx new-slug zk-luhmann-id-postfix)))
-           (current-files (zk--parse-id 'file-path (zk-index--current-id-list (buffer-name))))
+           (current-files (mapcar (lambda (id) (zk--parse-id 'file-path id))
+                                  (zk-index--current-id-list (buffer-name))))
            (files (remq nil
                         (mapcar
                          (lambda (x)


### PR DESCRIPTION
This change is required after Pull Request #62 to `zk` repo. However, even without it, making explicit the mapping over a list results in clearer code.